### PR TITLE
[codex] Initialize repository documentation baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,270 @@
+# AGENTS.md
+
+## Mission
+
+LatticeHarden is an open-source security engineering portfolio platform built to demonstrate secure end-to-end deployment of LLM-based systems.
+
+This repository is intentionally over-engineered for its use case. Do not optimize for the smallest possible implementation if that reduces the clarity, depth, or auditability of the security posture.
+
+When making trade-offs, prioritize in this order:
+1. Security
+2. Correctness
+3. Maintainability
+4. Auditability
+5. Simplicity
+6. Speed of implementation
+
+---
+
+## How to Use This File
+
+Use this document as the operational guide for working in the repository.
+
+- Follow these rules before making architectural or code changes.
+- If a topic requires deeper explanation, consult `docs/PROJECT_CONTEXT.md` and the documents listed in **Source of Truth**.
+- If an existing ADR conflicts with an ad hoc implementation idea, the ADR wins unless the task explicitly requires revisiting that decision.
+
+---
+
+## Source of Truth
+
+Before making changes, consult documents in this order:
+
+1. `AGENTS.md`
+2. `docs/adr/`
+3. `docs/architecture.md`
+4. `docs/threat-model.md`
+5. `docs/PROJECT_CONTEXT.md`
+6. module-local README files and existing tests
+
+Precedence rules:
+- If implementation differs from documentation, do not assume the code is correct. Investigate.
+- If multiple documents conflict, follow the highest-precedence source above.
+- If you introduce a significant architectural change, update or create an ADR.
+
+---
+
+## Non-Negotiable Rules
+
+### Security-first
+- Always prefer the more secure design when alternatives are otherwise comparable.
+- Assume all external input is hostile.
+- Prefer explicit controls over implicit assumptions.
+- Treat missing validation as a defect.
+
+### No secrets in code
+- Never hardcode API keys, passwords, tokens, certificates, or private keys.
+- Never commit real credentials, even in sample files.
+- Use placeholders such as `YOUR_SECRET_HERE`.
+- Do not bypass the project’s secret-management abstractions.
+
+### Least privilege everywhere
+- No wildcard permissions unless strictly unavoidable.
+- Scope IAM, RBAC, and network rules to the minimum needed.
+- If an exception is unavoidable, document the security rationale inline.
+
+### Defense in depth
+- Do not rely on a single control.
+- A failure in one layer should not fully compromise the system.
+
+### Security controls must be testable
+- Any meaningful security control must have a corresponding test.
+- Do not add auth, rate limiting, filtering, validation, or hardening logic without verifying expected behavior.
+
+### Security rationale must be documented
+- Every non-obvious security decision should explain:
+  - what threat it mitigates
+  - why this approach was chosen
+  - what trade-off it introduces
+
+---
+
+## Execution Rules
+
+When working on a task:
+
+1. Identify the relevant module and current project phase.
+2. Read applicable ADRs and local patterns before editing.
+3. Prefer the smallest correct change that fits the existing architecture.
+4. Preserve the security model unless the task explicitly changes it.
+5. Add or update tests.
+6. Update documentation if architecture, controls, or usage changed.
+
+Before finalizing a change, ask:
+- What threat does this mitigate?
+- Is there a simpler implementation with the same security guarantees?
+- What happens if this control fails?
+- Is blast radius constrained?
+- Is this consistent with roadmap and ADRs?
+
+---
+
+## Coding Standards
+
+### Python
+- Use Python 3.11+ conventions.
+- Type hints are mandatory on all function signatures.
+- Use Pydantic models for external inputs.
+- Do not pass raw, unvalidated user input through the system.
+- Security-relevant functions and modules must include docstrings.
+
+Use this module header pattern for security-relevant modules:
+
+```python
+"""
+Module: prompt_injection.py
+Purpose: Detect prompt injection attempts in LLM inputs before forwarding to the model.
+Threat mitigated: An attacker embedding instructions in user input that override
+system-level instructions or attempt data exfiltration.
+Reference: OWASP LLM Top 10 — LLM01: Prompt Injection
+"""
+```
+
+Additional requirements:
+- No SQL built by string concatenation.
+- No shell command construction from user input.
+- Prefer explicit validation and narrow failure modes.
+- `bandit` and `semgrep` should pass before merge.
+
+### FastAPI
+- Validate all request inputs with Pydantic v2 models.
+- Keep routes thin.
+- Put reusable security logic in services or middleware.
+- Do not leak internal implementation details in error messages.
+
+### Terraform
+- No hardcoded AMI IDs.
+- Use encrypted remote state with locking for real environments.
+- Tag resources consistently:
+  - `Environment`
+  - `Project = "latticeharden"`
+  - `ManagedBy = "terraform"`
+- Comment security-relevant resources with the threat they mitigate.
+
+### Kubernetes
+Required defaults unless explicitly justified:
+- `runAsNonRoot: true`
+- `readOnlyRootFilesystem: true`
+- `allowPrivilegeEscalation: false`
+- define `resources.requests`
+- define `resources.limits`
+
+Also:
+- Prefer deny-by-default network policy posture.
+- Keep RBAC minimal.
+- Document any privileged exception inline.
+
+### Docker
+- Do not use `latest` tags.
+- Pin versions explicitly.
+- Prefer multi-stage builds.
+- Minimize runtime attack surface.
+- Prefer hardened or distroless images where appropriate.
+
+### Git commits
+Use Conventional Commits, such as:
+- `feat(ai-security): add prompt injection classifier using regex and semantic checks`
+- `fix(api): enforce rate limiting on login endpoints`
+- `security(k8s): restrict egress from proxy namespace`
+- `docs(adr): record Vault decision for runtime secrets`
+
+---
+
+## CI/CD Expectations
+
+Security checks are part of the product.
+
+Expected controls include:
+- Semgrep
+- Trivy
+- TruffleHog
+- container scanning
+- manifest validation before deploy
+- DAST when phase-appropriate
+
+Do not bypass validation steps for convenience.
+
+Do not use `kubectl apply -f` in CI/CD without prior manifest validation such as `kubeconform` or equivalent.
+
+---
+
+## ADR Policy
+
+Create or update an ADR for:
+- major architectural choices
+- auth strategy changes
+- secrets management changes
+- infrastructure trust boundary changes
+- meaningful AI security design decisions
+- PQC integration decisions with security or complexity trade-offs
+
+Use this template:
+
+```md
+# ADR-001: Title
+
+## Status
+Proposed | Accepted | Deprecated
+
+## Context
+What problem are we solving? What are the constraints?
+
+## Decision
+What did we decide?
+
+## Security rationale
+Why is this decision the more secure choice? What threat does it mitigate?
+
+## Trade-offs
+What are we giving up? What complexity does this add?
+
+## Alternatives considered
+What else did we evaluate and why did we reject it?
+```
+
+---
+
+## Explicit Anti-Patterns
+
+Do not do the following:
+- Do not use n8n, Zapier, or other low-code automation tools in this repository.
+- Do not use `latest` image tags.
+- Do not commit credentials, including in example files.
+- Do not implement cryptographic primitives from scratch.
+- Do not add security controls without tests.
+- Do not skip validation in deployment workflows.
+- Do not broaden permissions just to make something work.
+- Do not introduce architectural drift without documenting it.
+
+---
+
+## Preferred Behavior for Code Changes
+
+When modifying or generating code for this repository:
+- be precise
+- be explicit
+- explain security rationale for non-obvious choices
+- avoid unnecessary abstraction
+- prefer secure defaults
+- keep implementations aligned with the documented structure
+- do not invent new architectural layers without justification
+
+When uncertain, prefer the option that is:
+1. more secure
+2. easier to audit
+3. easier to test
+4. more consistent with existing decisions
+
+---
+
+## Maintainer Intent
+
+This repository exists to demonstrate serious security engineering capability in a single coherent platform.
+
+Complexity is acceptable when it is deliberate, documented, testable, and security-motivated.
+
+When in doubt, optimize for:
+- demonstrable security depth
+- architectural clarity
+- technical credibility
+- consistency with the long-term platform vision

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -1,0 +1,398 @@
+# PROJECT_CONTEXT.md
+
+## Status
+
+This document describes the target architecture and phased implementation plan for LatticeHarden. It is a planning and alignment artifact, not a claim that every module below already exists in the repository today.
+
+## Overview
+
+LatticeHarden is an open-source security engineering portfolio project that demonstrates secure end-to-end deployment of LLM-based applications.
+
+It is not intended to be a lightweight product. It is a reference platform designed to showcase deep technical competency across multiple security domains inside one coherent repository.
+
+The project is intentionally over-engineered for its use case so it can demonstrate a wide range of practical security engineering patterns.
+
+---
+
+## Strategic Objective
+
+The project exists to demonstrate competency across four connected areas:
+
+1. DevSecOps platform security
+2. Application security
+3. AI security
+4. Post-quantum cryptography integration
+
+The value of the project is not only the final system, but the visibility of the reasoning behind each security decision.
+
+This means the repository should communicate:
+- threat awareness
+- secure defaults
+- layered controls
+- sound trade-off analysis
+- engineering maturity
+
+---
+
+## Architectural Layers
+
+### Layer 1 — DevSecOps Platform
+Purpose:
+- secure infrastructure as code
+- hardened CI/CD with security gates
+- container and runtime hardening
+- secure Kubernetes deployment patterns
+
+Representative capabilities:
+- Terraform-based AWS provisioning
+- least-privilege IAM
+- KMS-backed encryption strategy
+- secret-management integration
+- EKS hardening
+- security validation in delivery pipelines
+
+### Layer 2 — Application Security
+Purpose:
+- secure API design
+- strong validation and auth boundaries
+- threat-informed service implementation
+- secure middleware and API defenses
+
+Representative capabilities:
+- FastAPI with strict input validation
+- JWT and OAuth2-based auth patterns
+- rate limiting
+- request sanitization
+- SAST/DAST integration
+- OWASP Top 10-driven design decisions
+
+### Layer 3 — AI Security
+Purpose:
+- protect LLM workflows against common attack classes
+- evaluate attack/defense effectiveness
+- demonstrate practical AI red-teaming patterns
+
+Representative capabilities:
+- prompt injection detection
+- PII redaction
+- output filtering
+- jailbreak and data-extraction attack scenarios
+- adversarial ML experiments using ART
+- benchmark-driven evaluation before and after defenses
+
+### Layer 4 — Post-Quantum Cryptography
+Purpose:
+- demonstrate secure adoption of post-quantum tooling
+- benchmark performance and trade-offs
+- connect classical and PQC techniques in a hybrid model
+
+Representative capabilities:
+- Kyber-based key encapsulation via trusted libraries
+- Dilithium-based signatures via trusted libraries
+- hybrid TLS experiments
+- performance comparison across classical and PQC approaches
+
+---
+
+## Target Repository Structure
+
+```text
+lattice-harden/
+├── infra/                    # Terraform — AWS infrastructure as code
+│   ├── modules/
+│   │   ├── vpc/
+│   │   ├── eks/
+│   │   ├── iam/
+│   │   └── secrets/
+│   ├── environments/
+│   │   ├── dev/
+│   │   └── prod/
+│   └── README.md
+│
+├── api/                      # FastAPI application
+│   ├── app/
+│   │   ├── main.py
+│   │   ├── auth/
+│   │   ├── middleware/
+│   │   ├── routes/
+│   │   └── models/
+│   ├── tests/
+│   ├── Dockerfile
+│   └── requirements.txt
+│
+├── k8s/                      # Kubernetes manifests
+│   ├── base/
+│   ├── overlays/
+│   ├── rbac/
+│   ├── network-policies/
+│   └── pod-security/
+│
+├── security/                 # Security tooling and documentation
+│   ├── threat-model/
+│   ├── semgrep-rules/
+│   ├── trivy-config/
+│   └── dast/
+│
+├── ai-security/              # AI Security layer
+│   ├── proxy/
+│   │   ├── filters/
+│   │   │   ├── prompt_injection.py
+│   │   │   ├── pii_redactor.py
+│   │   │   └── output_filter.py
+│   │   └── main.py
+│   ├── red_team/
+│   │   ├── attacks/
+│   │   │   ├── prompt_injection/
+│   │   │   ├── jailbreak/
+│   │   │   └── data_extraction/
+│   │   └── adversarial/
+│   └── benchmarks/
+│
+├── pqc/                      # Post-Quantum Cryptography module
+│   ├── kyber/
+│   ├── dilithium/
+│   ├── hybrid_tls/
+│   └── benchmarks/
+│
+├── docs/
+│   ├── adr/
+│   ├── PROJECT_CONTEXT.md
+│   ├── threat-model.md
+│   └── architecture.md
+│
+└── .github/
+    └── workflows/
+        ├── security.yml
+        ├── container.yml
+        └── deploy.yml
+```
+
+This is the intended repository layout as the project matures.
+
+---
+
+## Technology Stack
+
+### Infrastructure
+- Terraform >= 1.6
+- AWS EKS
+- AWS VPC
+- AWS IAM
+- AWS KMS
+- AWS Secrets Manager
+- Helm >= 3.12
+
+### Application
+- Python >= 3.11
+- FastAPI >= 0.104
+- Pydantic v2 >= 2.4
+- Docker
+
+### Security Tooling
+- Semgrep
+- Trivy
+- TruffleHog
+- OWASP ZAP
+- Falco
+- HashiCorp Vault
+
+### AI Security
+- OpenAI API or Ollama
+- Adversarial Robustness Toolbox (ART)
+- LangChain
+- spaCy
+
+### Post-Quantum Cryptography
+- liboqs-python
+- OpenSSL 3.x with OQS provider
+
+---
+
+## Core Security Principles
+
+These principles should shape implementation decisions across the codebase.
+
+### Secrets management
+- Secrets must never be hardcoded.
+- The project should rely on managed secret stores and controlled injection mechanisms.
+- Terraform state must be protected with encryption and locking.
+
+### Least privilege
+- Every identity, service account, and policy should have only the permissions it actually needs.
+- Wildcards should be treated as exceptions, not defaults.
+- Network access should follow zero-trust assumptions.
+
+### Input validation
+- External inputs must be validated strictly.
+- Dangerous operations should not be constructed directly from user input.
+- Validation should occur as early as possible.
+
+### Defense in depth
+- Security controls should exist at multiple layers.
+- A control bypass should not collapse the entire system.
+
+### Decision traceability
+- Security-relevant choices should be explained.
+- Non-obvious trade-offs should be recorded in ADRs.
+
+---
+
+## Development Roadmap
+
+### Phase 0 — Foundation (April to June 2026)
+Goal:
+- establish repository presence
+- create CI/CD security pipeline
+- produce professional baseline documentation
+
+Deliverables:
+- full repository skeleton
+- English README
+- `security.yml` with Semgrep, Trivy, and TruffleHog on every PR
+- `docs/architecture.md`
+- `docs/threat-model.md`
+- basic FastAPI service for pipeline scanning
+
+Parallel study track:
+- ISC2 CC
+
+### Phase 1 — DevSecOps + AppSec Foundation (July to September 2026)
+Goal:
+- build secure working infrastructure and API foundation
+
+Deliverables:
+- Terraform modules for VPC, EKS, IAM, and secrets
+- FastAPI auth, rate limiting, and strict validation
+- hardened Docker build strategy
+- `container.yml` with image build and Trivy scan
+- initial K8s deployment with RBAC and NetworkPolicies
+- OWASP Top 10 coverage documented in threat-model artifacts
+
+Parallel study track:
+- AWS Solutions Architect Associate (SAA-C03)
+
+### Phase 2 — Advanced Security + AI Security (October 2026 to March 2027)
+Goal:
+- build production-grade security posture and AI security differentiators
+
+Deliverables:
+- Falco, Vault integration, pod security admission, OPA/Gatekeeper
+- DAST integration in staging
+- `ai-security/proxy/` with prompt injection detection, PII redaction, and output filtering
+- `ai-security/red_team/` attack tooling
+- `ai-security/benchmarks/` reproducible evaluation of defenses
+
+Parallel study track:
+- CKA
+- CKS
+
+### Phase 3 — PQC Integration + Capstone (January to December 2027)
+Goal:
+- complete the platform and integrate PQC as a capstone differentiator
+
+Deliverables:
+- `pqc/` modules for Kyber and Dilithium through trusted libraries
+- `pqc/hybrid_tls/` hybrid TLS experiments
+- `pqc/benchmarks/` for latency, throughput, and key-size comparisons
+- complete integrated demonstration across all layers
+- full README refresh with architecture, controls, and attack scenarios
+
+Parallel study track:
+- AWS Security Specialty
+- eWPTv2 or BSCP
+
+---
+
+## Coding and Documentation Conventions
+
+### Python
+- Type hints are mandatory.
+- Pydantic models should represent external inputs.
+- Security-relevant modules should explain purpose and threat mitigated.
+- Static and security analysis should pass before merge.
+
+Recommended module header pattern:
+
+```python
+"""
+Module: prompt_injection.py
+Purpose: Detect prompt injection attempts in LLM inputs before forwarding to the model.
+Threat mitigated: An attacker embedding instructions in user input that override
+                  system-level instructions or exfiltrate data.
+Reference: OWASP LLM Top 10 — LLM01: Prompt Injection
+"""
+```
+
+### Terraform
+- Security-relevant resources should document what they protect.
+- Use data sources instead of hardcoded machine identifiers.
+- Use remote state with encryption and locking.
+
+### Kubernetes
+- Non-root execution should be the default.
+- Read-only filesystem should be the default.
+- Privilege escalation should be disabled by default.
+- Resource requests and limits should always be declared.
+
+### Git history
+Use Conventional Commits to keep changes legible and categorized.
+
+---
+
+## Explicit Anti-Patterns
+
+The following are intentionally out of scope or prohibited:
+
+- low-code automation platforms such as n8n or Zapier inside this repository
+- `latest` Docker tags
+- storing credentials in the repository
+- implementing cryptography from scratch
+- shipping untested security controls
+- deploying unvalidated manifests in CI/CD
+
+These are not stylistic preferences. They are project constraints.
+
+---
+
+## ADR Guidance
+
+All significant architectural decisions should be documented in `docs/adr/`.
+
+Recommended format:
+
+```md
+# ADR-001: Title
+
+## Status
+Proposed | Accepted | Deprecated
+
+## Context
+What problem are we solving? What are the constraints?
+
+## Decision
+What did we decide?
+
+## Security rationale
+Why is this decision the more secure choice? What threat does it mitigate?
+
+## Trade-offs
+What are we giving up? What complexity does this add?
+
+## Alternatives considered
+What else did we evaluate and why did we reject it?
+```
+
+---
+
+## Maintainer Intent
+
+This project should feel like a coherent security engineering platform, not a random collection of demos.
+
+Every addition should reinforce at least one of these qualities:
+- security depth
+- architectural discipline
+- clear threat rationale
+- practical credibility
+- long-term capstone coherence
+
+The project is allowed to be ambitious and layered. It is not allowed to be sloppy, arbitrary, or security-theater.

--- a/docs/adr/ADR-001-foundation-architecture.md
+++ b/docs/adr/ADR-001-foundation-architecture.md
@@ -1,0 +1,73 @@
+# ADR-001: Security-First Reference Architecture Foundation
+
+## Status
+
+Accepted
+
+## Context
+
+LatticeHarden is being built as an open-source security engineering portfolio platform for secure LLM system deployment. At the current repository stage, the implementation footprint is intentionally small, but the project already needs a coherent architectural direction so future code, infrastructure, and documentation changes remain aligned.
+
+Without a documented foundation decision, the repository risks:
+
+- architectural drift as new modules are added
+- inconsistent security assumptions across infrastructure, application, and AI layers
+- security controls being implemented without clear rationale or test expectations
+- public documentation overstating or misrepresenting the intended system design
+
+## Decision
+
+The project adopts a security-first reference architecture organized into four layers:
+
+1. DevSecOps platform security
+2. Application security
+3. AI security
+4. Post-quantum cryptography experimentation
+
+The repository will treat architecture documents, ADRs, and threat modeling artifacts as first-class implementation inputs, not after-the-fact documentation.
+
+The project will also use these operating rules:
+
+- prioritize security over simplicity or implementation speed when trade-offs are material
+- require explicit validation at external boundaries
+- prefer least privilege across IAM, RBAC, and network controls
+- require tests for meaningful security controls
+- document significant architectural changes in ADRs
+- use trusted security and cryptographic tooling rather than custom primitives
+
+## Security Rationale
+
+This decision is the more secure choice because it forces trust boundaries, control layering, and trade-offs to be explicit before the implementation surface expands.
+
+Threats mitigated include:
+
+- insecure defaults introduced through undocumented growth
+- excessive privilege caused by ad hoc infrastructure and runtime changes
+- weak or missing validation at application and AI boundaries
+- misleading security claims caused by undocumented assumptions
+
+By anchoring the repository to a layered model and ADR discipline, future changes become easier to audit, test, and challenge.
+
+## Trade-offs
+
+This decision adds:
+
+- more documentation overhead up front
+- stricter expectations for tests and rationale
+- slower implementation when compared with an ad hoc prototype
+
+These trade-offs are accepted because the repository's purpose is to demonstrate deliberate security engineering, not only feature delivery.
+
+## Alternatives Considered
+
+### Minimal prototype first, architecture later
+
+Rejected because it would optimize for speed at the expense of security clarity and would make later hardening harder to audit.
+
+### Application-only scope without infrastructure and AI layers
+
+Rejected because it would not demonstrate the end-to-end security posture the project is intended to showcase.
+
+### Rapid experimentation without ADR requirements
+
+Rejected because it would make non-obvious security decisions harder to trace and review over time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,184 @@
+# Architecture
+
+## Status
+
+This document describes the target architecture for LatticeHarden's initial foundation. It is intended to guide implementation and documentation as the repository grows from the current baseline.
+
+## Overview
+
+LatticeHarden is an open-source security engineering portfolio platform built to demonstrate secure end-to-end deployment of LLM-based systems. The repository is intentionally designed as a reference implementation, not a minimal product, so that security rationale, controls, and trade-offs remain visible and auditable.
+
+The architecture is organized around four layers:
+
+1. DevSecOps platform security
+2. Application security
+3. AI security
+4. Post-quantum cryptography experimentation
+
+Each layer must remain aligned with the repository-wide priorities defined in [AGENTS.md](/mnt/c/Users/berna/lattice-harden/AGENTS.md:1):
+
+1. Security
+2. Correctness
+3. Maintainability
+4. Auditability
+5. Simplicity
+6. Speed of implementation
+
+## Architectural Goals
+
+The platform should:
+
+- demonstrate secure-by-default engineering patterns across infrastructure, application, and AI boundaries
+- make non-obvious security decisions easy to inspect through code, tests, and ADRs
+- constrain blast radius when a single control fails
+- separate concerns so that controls can be verified independently
+- prefer well-known, trusted tooling over ad hoc security mechanisms
+
+## Target Repository Layout
+
+The repository is expected to evolve toward the following structure:
+
+```text
+lattice-harden/
+├── infra/                    # Terraform for cloud infrastructure
+├── api/                      # FastAPI application and tests
+├── k8s/                      # Kubernetes manifests and policies
+├── security/                 # Security tooling, rules, and DAST assets
+├── ai-security/              # LLM filtering, red team, and benchmarks
+├── pqc/                      # Post-quantum cryptography experiments
+├── docs/
+│   ├── adr/
+│   ├── architecture.md
+│   ├── PROJECT_CONTEXT.md
+│   └── threat-model.md
+└── .github/workflows/        # CI/CD and security automation
+```
+
+This is a target layout, not a claim that all modules are already implemented.
+
+## Layered Design
+
+### Layer 1: DevSecOps Platform Security
+
+This layer establishes the trusted execution foundation for the rest of the system.
+
+Primary responsibilities:
+
+- define infrastructure as code using Terraform
+- provision cloud resources with least-privilege IAM
+- enforce encryption, network segmentation, and secret-management integrations
+- validate infrastructure and manifests in CI/CD before deployment
+- harden container build and runtime defaults
+
+Representative controls:
+
+- encrypted state and locking for real Terraform environments
+- narrow IAM policies and explicit trust relationships
+- hardened Kubernetes defaults such as non-root execution and read-only filesystems
+- manifest validation before deploy
+- image and dependency scanning in CI/CD
+
+### Layer 2: Application Security
+
+This layer defines the API and service boundaries that process external input.
+
+Primary responsibilities:
+
+- expose a narrow, validated FastAPI surface
+- enforce strict input models using Pydantic v2
+- keep routes thin and move reusable security logic into services or middleware
+- avoid leakage of internal implementation details in errors
+- enforce authentication, authorization, and abuse controls as the platform matures
+
+Representative controls:
+
+- strict request validation
+- narrow failure modes
+- rate limiting and sanitization patterns
+- explicit separation between transport, validation, and business logic
+
+### Layer 3: AI Security
+
+This layer protects LLM-assisted workflows against attack classes that do not exist in traditional applications alone.
+
+Primary responsibilities:
+
+- inspect user-controlled prompts before model execution
+- redact or block sensitive inputs and outputs
+- measure defense effectiveness against representative attack scenarios
+- document AI-specific trade-offs through repeatable tests and benchmarks
+
+Representative controls:
+
+- prompt injection detection
+- PII redaction
+- output filtering
+- red-team scenarios for jailbreak, prompt injection, and data extraction
+
+### Layer 4: Post-Quantum Cryptography
+
+This layer demonstrates controlled adoption of post-quantum tools without inventing cryptographic primitives.
+
+Primary responsibilities:
+
+- evaluate trusted PQC libraries and integration patterns
+- compare hybrid and classical approaches
+- document operational and performance trade-offs
+
+Representative controls:
+
+- use trusted libraries rather than custom implementations
+- isolate experiments from core application security assumptions
+- benchmark latency, throughput, and interoperability impacts
+
+## Trust Boundaries
+
+The system should be designed around explicit trust boundaries:
+
+1. External users and clients are untrusted.
+2. Public API ingress is untrusted until validated.
+3. Internal services are not automatically trusted; access should be authenticated and narrowly scoped.
+4. LLM inputs and outputs are untrusted data flows and must be filtered accordingly.
+5. CI/CD is a privileged path and must enforce validation before artifacts reach runtime environments.
+6. Cloud control plane and secret stores are trusted only through tightly scoped identities and audited access paths.
+
+## Security Design Principles
+
+The following principles govern architecture choices:
+
+- validate early and explicitly
+- assume hostile input at every external boundary
+- favor defense in depth over single-point controls
+- minimize privileges for identities, workloads, and network paths
+- prefer managed, auditable controls over bespoke mechanisms
+- ensure every meaningful control is testable
+- record non-obvious decisions in ADRs
+
+## Deployment View
+
+At maturity, the expected deployment flow is:
+
+1. Code changes are pushed through pull requests.
+2. CI/CD runs security checks such as Semgrep, Trivy, secret scanning, and manifest validation.
+3. Container images are built from pinned, hardened bases.
+4. Infrastructure and Kubernetes resources are validated before deployment.
+5. Runtime workloads execute with restricted privileges and explicit network policies.
+6. LLM-facing paths apply security filtering before and after model invocation.
+
+## Non-Goals
+
+The architecture intentionally does not optimize for:
+
+- minimal implementation size at the expense of security clarity
+- rapid feature delivery that bypasses validation or review
+- undocumented shortcuts that broaden privilege or reduce auditability
+- custom cryptographic primitives
+
+## Documentation Requirements
+
+When the architecture changes materially:
+
+- update this document
+- update the threat model if trust boundaries or attack surfaces change
+- create or revise an ADR for significant architectural decisions
+- add or update tests for relevant controls

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,225 @@
+# Threat Model
+
+## Status
+
+This document defines the initial threat model for LatticeHarden's foundation phase. It is intentionally high level and should be refined as concrete modules are implemented.
+
+## Scope
+
+LatticeHarden is an open-source platform intended to demonstrate secure deployment patterns for LLM-based systems. The threat model covers:
+
+- repository and CI/CD trust assumptions
+- infrastructure and deployment risks
+- API-facing application risks
+- AI-specific attack classes
+- misuse risks introduced by future PQC experimentation
+
+The model does not assume production traffic today. It exists to guide secure design before implementation expands.
+
+## Security Objectives
+
+The system should preserve:
+
+1. Confidentiality of secrets, tokens, and sensitive user data
+2. Integrity of source code, build artifacts, and deployment manifests
+3. Availability of core services under reasonable abuse conditions
+4. Integrity of LLM control flow and output handling
+5. Auditability of security-relevant decisions and changes
+
+## Assets
+
+Primary assets include:
+
+- source code and infrastructure definitions
+- CI/CD workflow definitions and generated artifacts
+- cloud credentials and secret references
+- application authentication material
+- LLM prompts, completions, and filtering logic
+- security rules, findings, and benchmark data
+
+## Threat Actors
+
+Relevant threat actors include:
+
+- anonymous internet attackers probing public endpoints
+- malicious or careless contributors introducing unsafe changes
+- automated scanners and credential harvesters targeting public repositories
+- attackers attempting prompt injection, jailbreaks, or data extraction via LLM workflows
+- attackers seeking privilege escalation through CI/CD, containers, or Kubernetes misconfiguration
+
+## Trust Boundaries
+
+The initial design recognizes these boundaries:
+
+1. Developer workstation to repository
+2. Repository to CI/CD execution
+3. CI/CD to cloud or cluster deployment targets
+4. External client to API ingress
+5. API services to internal components
+6. Application logic to LLM provider or local model runtime
+7. Runtime workloads to secret stores and control-plane services
+
+Every boundary crossing must be authenticated, validated, or otherwise constrained.
+
+## Assumptions
+
+The threat model assumes:
+
+- all external input is hostile until validated
+- public repositories will be continuously scanned by automated tooling
+- cloud identities and CI/CD credentials are high-value targets
+- LLM outputs are not inherently trustworthy
+- security controls can fail and must be layered
+
+## Primary Threats
+
+### Supply Chain and Repository Threats
+
+Threats:
+
+- accidental credential exposure
+- malicious dependency introduction
+- unsafe workflow changes
+- poisoned container bases or unpinned toolchains
+
+Mitigations:
+
+- no secrets in code or examples
+- pinned versions where practical
+- mandatory security scanning in CI/CD
+- code review and ADR-backed architectural changes
+
+### CI/CD and Artifact Integrity Threats
+
+Threats:
+
+- unauthorized workflow modification
+- unvalidated manifests reaching deployment targets
+- artifact tampering between build and deploy stages
+
+Mitigations:
+
+- validation gates before deploy
+- explicit manifest validation
+- container scanning and policy checks
+- minimal permissions for automation identities
+
+### Infrastructure Misconfiguration Threats
+
+Threats:
+
+- over-broad IAM permissions
+- publicly exposed internal services
+- unencrypted state or storage
+- weak network segmentation
+
+Mitigations:
+
+- least-privilege IAM
+- deny-by-default network posture where feasible
+- encrypted state and managed secret stores
+- documented security rationale for exceptions
+
+### Application Security Threats
+
+Threats:
+
+- injection through unvalidated inputs
+- broken authentication or authorization boundaries
+- sensitive error leakage
+- abuse through missing rate limits or insufficient request controls
+
+Mitigations:
+
+- strict Pydantic validation
+- thin routes and reusable middleware or services
+- narrow error handling
+- test coverage for security-relevant controls
+
+### AI Security Threats
+
+Threats:
+
+- prompt injection
+- jailbreak attempts
+- data extraction through model manipulation
+- sensitive data disclosure in prompts or outputs
+- unsafe tool invocation triggered by model-influenced content
+
+Mitigations:
+
+- prompt filtering before model execution
+- output filtering and redaction
+- benchmarked attack/defense testing
+- explicit separation between validated inputs, model calls, and post-processing
+
+### Kubernetes and Runtime Threats
+
+Threats:
+
+- container escape amplification through weak runtime settings
+- lateral movement across namespaces or services
+- privilege escalation inside workloads
+
+Mitigations:
+
+- `runAsNonRoot: true`
+- `readOnlyRootFilesystem: true`
+- `allowPrivilegeEscalation: false`
+- declared resource requests and limits
+- minimal RBAC and restrictive network policies
+
+### PQC Experimentation Risks
+
+Threats:
+
+- misleading security claims from immature integrations
+- incorrect use of experimental cryptographic tooling
+- operational instability from hybrid experiments
+
+Mitigations:
+
+- use trusted libraries only
+- treat PQC work as explicit experimentation until validated
+- document trade-offs and benchmark impacts
+
+## Abuse Cases
+
+Representative abuse cases the project should eventually test:
+
+1. A user submits input designed to override system instructions in an LLM workflow.
+2. A contributor introduces a workflow change that weakens scanning or validation.
+3. A container or manifest is configured with unnecessary privilege.
+4. A route accepts raw user input and passes it to a dangerous sink without validation.
+5. A secret is accidentally added to code, examples, or commit history.
+
+## Control Failure Analysis
+
+If a single control fails:
+
+- validation failures should still be constrained by downstream business logic and runtime permissions
+- CI/CD bypass should still face repository review, scanning in adjacent stages, and deployment policy checks
+- prompt filtering failure should still be constrained by output filtering and narrow tool permissions
+- runtime compromise should still face namespace, RBAC, and network boundaries
+
+This reflects the repository requirement for defense in depth rather than reliance on one guardrail.
+
+## Validation Strategy
+
+Security controls are only meaningful if tested. As implementation progresses, the project should maintain:
+
+- unit tests for validation and filtering logic
+- integration tests for auth, API boundaries, and middleware behavior
+- CI/CD checks for static analysis, secrets detection, and artifact scanning
+- manifest validation before deployment
+- AI red-team and benchmark scenarios for defense effectiveness
+
+## Open Questions
+
+These questions should be resolved through ADRs and implementation:
+
+- what authentication model is used for public and internal APIs
+- what secret-management path is used in each environment
+- what deployment promotion model is trusted in CI/CD
+- what model provider trust assumptions apply to AI workloads
+- what PQC experiments remain isolated from production-like paths


### PR DESCRIPTION
What changed:
This PR establishes the initial repository documentation baseline with AGENTS, project context, architecture, threat model, and ADR foundation documents.

Why it changed:
The repository needed a coherent public-facing security and architecture baseline before implementation expands.

Impact:
This is a documentation-only initialization PR.

Validation:
Documentation was reviewed for consistency and the referenced docs paths now exist.